### PR TITLE
Fixup some spelling errors in comments

### DIFF
--- a/cmake/FindGcov.cmake
+++ b/cmake/FindGcov.cmake
@@ -19,7 +19,7 @@ set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
 
 get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
 foreach (LANG ${ENABLED_LANGUAGES})
-	# Gcov evaluation is dependend on the used compiler. Check gcov support for
+	# Gcov evaluation is dependent on the used compiler. Check gcov support for
 	# each compiler that is used. If gcov binary was already found for this
 	# compiler, do not try to find it again.
 	if (NOT GCOV_${CMAKE_${LANG}_COMPILER_ID}_BIN)

--- a/cmake/Findcodecov.cmake
+++ b/cmake/Findcodecov.cmake
@@ -68,13 +68,13 @@ endif ()
 
 
 
-# Find the reuired flags foreach language.
+# Find the required flags foreach language.
 set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
 set(CMAKE_REQUIRED_QUIET ${codecov_FIND_QUIETLY})
 
 get_property(ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
 foreach (LANG ${ENABLED_LANGUAGES})
-	# Coverage flags are not dependend on language, but the used compiler. So
+	# Coverage flags are not dependent on language, but the used compiler. So
 	# instead of searching flags foreach language, search flags foreach compiler
 	# used.
 	set(COMPILER ${CMAKE_${LANG}_COMPILER_ID})


### PR DESCRIPTION
We used an automated tool to check for spelling errors in our project and found some in CMake files we use from here, so I thought I would contribute the fixes back.