### PR TITLE
When comparing for a file's language type only consider the last part of the file extension

### DIFF
--- a/cmake/Findcodecov.cmake
+++ b/cmake/Findcodecov.cmake
@@ -133,7 +133,7 @@ set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})
 
 # Helper function to get the language of a source file.
 function (codecov_lang_of_source FILE RETURN_VAR)
-	get_filename_component(FILE_EXT "${FILE}" EXT)
+	get_filename_component(FILE_EXT "${FILE}" LAST_EXT)
 	string(TOLOWER "${FILE_EXT}" FILE_EXT)
 	string(SUBSTRING "${FILE_EXT}" 1 -1 FILE_EXT)
 


### PR DESCRIPTION
Currently, code coverage is failing due to the naming of files in my project.  Test files take the form <name of the source-file being tested>.tests.cpp.  This is failing because the code coverage module then looks to see if the file extension ".tests.cpp" is supported by any compiler and unsurprisingly it's not.

This is caused by calling the [get_filename_component function with the EXT parameter](https://cmake.org/cmake/help/latest/command/get_filename_component.html).  This is fixed by calling with the LAST_EXT parameter which only considers file extension after the final dot separator. 