### PR TITLE
add support for Ninja

### DIFF
--- a/cmake/FindGcov.cmake
+++ b/cmake/FindGcov.cmake
@@ -141,9 +141,9 @@ function (add_gcov_target TNAME)
 
 		# call gcov
 		add_custom_command(OUTPUT ${TDIR}/${FILE}.gcov
-			COMMAND ${GCOV_ENV} ${GCOV_BIN} ${TDIR}/${FILE}.gcno > /dev/null
+			COMMAND ${GCOV_ENV} ${GCOV_BIN} -p ${TDIR}/${FILE}.gcno > /dev/null
 			DEPENDS ${TNAME} ${TDIR}/${FILE}.gcno
-			WORKING_DIRECTORY ${FILE_PATH}
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 		)
 
 		list(APPEND BUFFER ${TDIR}/${FILE}.gcov)


### PR DESCRIPTION
When cmake generator is Ninja, the source path is relative to CMAKE_CURRENT_BINARY_DIR. 