### PR TITLE
Ensure no left over state is left in the required flags variable

### DIFF
--- a/cmake/Findcodecov.cmake
+++ b/cmake/Findcodecov.cmake
@@ -112,6 +112,8 @@ foreach (LANG ${ENABLED_LANGUAGES})
 				endif ()
 			endif()
 
+			unset(CMAKE_REQUIRED_FLAGS)
+
 			if (COVERAGE_FLAG_DETECTED)
 				set(COVERAGE_${COMPILER}_FLAGS "${FLAG}"
 					CACHE STRING "${COMPILER} flags for code coverage.")


### PR DESCRIPTION
I'm raising this PR to fix a bug when using the code coverage modules with a build that includes the [HDF5 library](https://github.com/HDFGroup/hdf5).  HDF5 uses the `CMAKE_REQUIRED_FLAGS` with try_compile, however, because it appends to `CMAKE_REQUIRED_FLAGS` its is picking up the leftover code coverage flags from the coverage module.  All of the calls to `try_compile` now fail because gcov is not added as a linker flag as well:

```
-- try_compile: {COMPILE_DEFINITIONS: -DSTDC_HEADERS -O0 -g -fprofile-arcs -ftest-coverage -DHAVE_SYS_TIME_H -DHAVE_UNISTD_H -DHAVE_SYS_TYPES_H -DHAVE_SYS_SOCKET_H, LINK_LIBRARIES: m;dl, OUTPUT_VARIABLE: Change Dir: /home/toro/build/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/local/bin/ninja cmTC_df3b4 && [1/2] Building C object CMakeFiles/cmTC_df3b4.dir/HDFTests.c.o
[2/2] Linking C executable cmTC_df3b4
FAILED: cmTC_df3b4 
: && /opt/ccache-3.7.9/bin/cc   -static-libstdc++ -static-libgcc -pthread -lrt -ldl CMakeFiles/cmTC_df3b4.dir/HDFTests.c.o  -o cmTC_df3b4  -lm  -ldl && :
/home/antony/packages/hdf5/original/config/cmake_ext_mod/HDFTests.c:115: error: undefined reference to '__gcov_init'
/home/antony/packages/hdf5/original/config/cmake_ext_mod/HDFTests.c:115: error: undefined reference to '__gcov_exit'
CMakeFiles/cmTC_df3b4.dir/HDFTests.c.o(.data+0x60): error: undefined reference to '__gcov_merge_add'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

While is this arguably an error with the way HDF5 uses `CMAKE_REQUIRED_FLAGS` I think it makes sense to fix this here, because there may be other libraries out in the wild that makes similar assumptions about the usage of `CMAKE_REQUIRED_FLAGS`.  Additionally, as this is the location the values originate from, and they are not longer needed after the check this seems the correct place to address the issue by resetting the values to their default state.
