### PR TITLE
use cmake current source dir to get correct path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif ()
 #
 # cmake configuration
 #
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 enable_testing()
 


### PR DESCRIPTION
Using the repo as third party library using FetchContent failed:
```
 FetchContent_Declare(
       cmake-codecov
       GIT_REPOSITORY https://github.com/RWTH-HPC/CMake-codecov.git
)
FetchContent_MakeAvailable(cmake-codecov) 
```
with the following error message:
```
CMake Error at build/_deps/cmake-codecov-src/src/libfoo/CMakeLists.txt:13 (add_coverage):
  Unknown CMake command "add_coverage".
```

This PR fix the issue by using the correct cmake variable in `CMakeLists.txt`