### PR TITLE
Fix branch coverage

### DIFF
--- a/cmake/FindLcov.cmake
+++ b/cmake/FindLcov.cmake
@@ -294,7 +294,6 @@ function (lcov_capture_tgt TNAME)
 	file(MAKE_DIRECTORY ${LCOV_HTML_PATH}/${TNAME})
 	add_custom_target(${TNAME}-genhtml
 		COMMAND ${GENHTML_BIN} --quiet --sort --prefix ${PROJECT_SOURCE_DIR}
-			--baseline-file ${LCOV_DATA_PATH_INIT}/${TNAME}.info
 			--output-directory ${LCOV_HTML_PATH}/${TNAME}
 			--title "${CMAKE_PROJECT_NAME} - target ${TNAME}"
 			${GENHTML_CPPFILT_FLAG} ${OUTFILE}
@@ -327,7 +326,6 @@ function (lcov_capture)
 		file(MAKE_DIRECTORY ${LCOV_HTML_PATH}/all_targets)
 		add_custom_target(lcov
 			COMMAND ${GENHTML_BIN} --quiet --sort
-				--baseline-file ${LCOV_DATA_PATH_INIT}/all_targets.info
 				--output-directory ${LCOV_HTML_PATH}/all_targets
 				--title "${CMAKE_PROJECT_NAME}" --prefix "${PROJECT_SOURCE_DIR}"
 				${GENHTML_CPPFILT_FLAG} ${OUTFILE}

--- a/src/bar/bar.c
+++ b/src/bar/bar.c
@@ -17,6 +17,12 @@
 int
 main (int argc, char** argv)
 {
+	if (argc == 1)
+	{
+		printf("Zero arg\n");
+		return 0;
+	}
+
 	if (*argv[1] == '1')
 		printf("%d\n", foo());
 	else if (*argv[1] == '2')


### PR DESCRIPTION
Fixes #36 

`genhtml --baseline-file` option was preventing branch coverage output in HTML.

This PR removes the `--baseline-file` option. I'm not 100% sure about the backward compatibility and other use cases it might affect.

Please review.
