### PR TITLE
Silence warning chatter

### DIFF
--- a/cmake/Findcodecov.cmake
+++ b/cmake/Findcodecov.cmake
@@ -122,7 +122,7 @@ foreach (LANG ${ENABLED_LANGUAGES})
 					CACHE STRING "${COMPILER} flags for code coverage.")
 				mark_as_advanced(COVERAGE_${COMPILER}_FLAGS)
 				break()
-			else ()
+			elseif (NOT CMAKE_REQUIRED_QUIET)
 				message(WARNING "Code coverage is not available for ${COMPILER}"
 				        " compiler. Targets using this compiler will be "
 				        "compiled without it.")


### PR DESCRIPTION
This resolves:
* #42 

To make use of it, turn on the existing cache var to control verbosity: `-Dcodecov_FIND_QUIETLY=ON`.