### PR TITLE
Bump CMake version and remove outdated code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,24 +10,12 @@
 
 
 # minimum required cmake version
-cmake_minimum_required(VERSION 2.8.12)
-
-
-# choose new behaviour for CMP0042
-# see http://www.cmake.org/cmake/help/v3.0/policy/CMP0042.html for more details
-if (POLICY CMP0042)
-	cmake_policy(SET CMP0042 NEW)
-endif (POLICY CMP0042)
-
+cmake_minimum_required(VERSION 3.10)
 
 #
 # project information
 #
-if (${CMAKE_MAJOR_VERSION} EQUAL 3)
-	project("test" LANGUAGES C Fortran)
-else ()
-	project("test" C Fortran)
-endif ()
+project("test" LANGUAGES C Fortran)
 
 
 #

--- a/src/bar/CMakeLists.txt
+++ b/src/bar/CMakeLists.txt
@@ -10,17 +10,9 @@
 
 
 include_directories(../libfoo ../libheader)
-if ("${CMAKE_VERSION}" VERSION_LESS "3.0.2")
-	include_directories(../libheader)
-endif ()
-
 add_executable(bar bar.c)
-
 target_link_libraries(bar foo)
-if ("${CMAKE_VERSION}" VERSION_GREATER "3.0.2")
-	target_link_libraries(bar header)
-endif()
-
+target_link_libraries(bar header)
 
 add_test(test1 ${CMAKE_CURRENT_BINARY_DIR}/bar 1)
 add_test(test2 ${CMAKE_CURRENT_BINARY_DIR}/bar 2)

--- a/src/libheader/CMakeLists.txt
+++ b/src/libheader/CMakeLists.txt
@@ -8,7 +8,5 @@
 # Written by Alexander Haase, alexander.haase@rwth-aachen.de
 #
 
-if ("${CMAKE_VERSION}" VERSION_GREATER "3.0.2")
-	add_library(header INTERFACE)
-	target_include_directories(header INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-endif ()
+add_library(header INTERFACE)
+target_include_directories(header INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This updates the required CMake version for the example project to 3.10 and removes outdated code (such as setting CMP0042 to new and other version checks).